### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/EmaSuriano/portfolio/security/code-scanning/6](https://github.com/EmaSuriano/portfolio/security/code-scanning/6)

In general, to fix this class of issue, you explicitly restrict `GITHUB_TOKEN` permissions in the workflow using a `permissions:` block either at the root of the workflow (applies to all jobs) or within individual jobs (per‑job overrides). You grant only the scopes actually required (commonly `contents: read` for typical CI that only needs to read the repo).

For this specific workflow, the job only checks out the repository, installs dependencies, builds, runs tests, and uploads artifacts. None of those steps require write access to the repository or elevated scopes like `pull-requests: write`. The minimal safe permissions are therefore `contents: read`. The cleanest fix is to add a top‑level `permissions:` block under the workflow `name:` (or before `jobs:`) that sets `contents: read`. This keeps existing functionality intact while ensuring the `GITHUB_TOKEN` is not granted unnecessary rights. No extra imports or dependencies are needed because this is a YAML configuration change only.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Add:

  ```yaml
  permissions:
    contents: read
  ```

  after the `name: ci` line (or anywhere at the root level before `jobs:`).  
- Leave the existing `jobs:` and steps unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
